### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Once you find a config you like, click on the link in the readme to be taken to 
 
 ### SubdivisionsMatchesMax Configurations
 
-If a configuration you like mentions needing `SubdivisionsMatchesMax`, you will need a forked version of bar brawl, provided by valkyrion's gitlab repo. ([Foundry v11](https://gitlab.com/msprijatelj/foundryvtt-bar-brawl/-/archive/v1.8.5-1-v11-extended/foundryvtt-bar-brawl-v1.8.5-1-v11-extended.zip)) leads to a zip file that can be downloaded. the parent folder `barbrawl` should replace your current `barbrawl` folder, generally in the following location: `\FoundryVTT\Data\modules\`
+If a configuration you like mentions needing `SubdivisionsMatchesMax`, you will need a forked version of bar brawl, provided by valkyrion's gitlab repo. ([Foundry v11](https://gitlab.com/msprijatelj/foundryvtt-bar-brawl/-/archive/v1.8.5-2-v11-extended/foundryvtt-bar-brawl-v1.8.5-2-v11-extended.zip)) leads to a zip file that can be downloaded. use the contents inside the `src` folder to replace the contents inside your current `barbrawl` folder, generally in the following location: `\FoundryVTT\Data\modules\`
 ___
 # Bar Brawl Configs
 


### PR DESCRIPTION
Updates the link to Valkyrion's Bar Brawl fork to version 1.8.5-2, which fixes the error present in version 1.8.5-1 that causes approximation automation to not function. Also updates the instructions to more accurately explain how to install the fork from the downloaded zip.