### PR TITLE
set default bars on prototype tokens

### DIFF
--- a/v11/BB_Bolts_v11.js
+++ b/v11/BB_Bolts_v11.js
@@ -61,7 +61,7 @@ barConfig['deployable'] = bars;
 await game.settings.set("barbrawl", "defaultTypeResources", barConfig);
 
 // :warning: Reset all actors' prototype token bars
-await Promise.all(game.actors.map(a => a.update({ "token.flags.barbrawl.-=resourceBars": null })));
+await Promise.all(game.actors.map(a => a.update({ "token.flags.barbrawl.resourceBars": bars }, {'diff': false, 'recursive': false})));
 
 // Reset the bars on all existing tokens
 await Promise.all(
@@ -72,7 +72,7 @@ await Promise.all(
         "flags.barbrawl.resourceBars": bars,
       };
     });
-    return s.updateEmbeddedDocuments("Token", updates);
+    return s.updateEmbeddedDocuments("Token", updates, {'diff': false, 'recursive': false});
   })
 );
 

--- a/v11/BB_Valkyrion_v11.js
+++ b/v11/BB_Valkyrion_v11.js
@@ -197,6 +197,19 @@ const pilotBars = {
     label: null,
     style: null
   },
+  bar2: {
+    id: "bar2",
+    ignoreMax: true,
+    ignoreMin: false,
+    mincolor: "#700000",
+    maxcolor: "#ff0000",
+    position: "bottom-outer",
+    attribute: "heat",
+    ownerVisibility: CONST.TOKEN_DISPLAY_MODES.ALWAYS,
+    otherVisibility: CONST.TOKEN_DISPLAY_MODES.ALWAYS,
+    label: null,
+    style: null
+  },
   burn: {
     id: "burn",
     mincolor: "#992222",
@@ -272,9 +285,6 @@ barConfig['deployable'] = deployableBars;
 
 await game.settings.set("barbrawl", "defaultTypeResources", barConfig);
 
-// :warning: Reset all actors' prototype token bars
-await Promise.all(game.actors.map(a => a.update({ "prototypeToken.flags.barbrawl.-=resourceBars": null })));
-
 // Reset the bars on all existing actor Prototype Tokens
 await Promise.all(
   game.actors.map(a => {
@@ -293,7 +303,7 @@ await Promise.all(
       default:
         break;
     }
-    a.update({ "prototypeToken.flags.barbrawl.resourceBars": barSettings })
+    a.update({ "prototypeToken.flags.barbrawl.resourceBars": barSettings }, {'diff': false, 'recursive': false})
   })
 );
 
@@ -323,7 +333,7 @@ await Promise.all(
         "flags.barbrawl.resourceBars": barSettings,
       };
     });
-    return s.updateEmbeddedDocuments("Token", updates);
+    return s.updateEmbeddedDocuments("Token", updates, {'diff': false, 'recursive': false});
   })
 );
 

--- a/v11/BB_Zenn_v11/BB_Zenn_V11.js
+++ b/v11/BB_Zenn_v11/BB_Zenn_V11.js
@@ -327,10 +327,6 @@ const deployableBars = {
   },
 };
 
-
-// Reset all prototype token bars for all actors
-await Promise.all(game.actors.map(a => a.update({ "token.flags.barbrawl.-=resourceBars": null })));
-
 // Apply new bar settings to all prototype tokens
 await Promise.all(game.actors.map(a => {
   let barSettings = mechBars;
@@ -347,20 +343,13 @@ await Promise.all(game.actors.map(a => {
     default:
       break;
   }
-  return a.update({ "token.flags.barbrawl.resourceBars": barSettings });
+  return a.update({ "token.flags.barbrawl.resourceBars": barSettings }, {'diff': false, 'recursive': false});
 }));
 
 // Reset all tokens' bars in all scenes
 await Promise.all(
   game.scenes.map(async s => {
-    // First, reset the bars
-    const resetUpdates = s.tokens.filter(t => t.actor).map(t => ({
-      _id: t.id,
-      "flags.barbrawl.-=resourceBars": null,
-    }));
-    await s.updateEmbeddedDocuments("Token", resetUpdates);
-
-    // Then, apply the new bar settings
+    // Apply the new bar settings
     const updates = s.tokens.filter(t => t.actor).map(t => {
       let barSettings = mechBars;
       switch (t.actor.type) {
@@ -381,7 +370,7 @@ await Promise.all(
         "flags.barbrawl.resourceBars": barSettings,
       };
     });
-    return s.updateEmbeddedDocuments("Token", updates);
+    return s.updateEmbeddedDocuments("Token", updates, {'diff': false, 'recursive': false});
   })
 );
 

--- a/v11/BB_dodgepong_v11.js
+++ b/v11/BB_dodgepong_v11.js
@@ -281,8 +281,27 @@ barConfig['deployable'] = deployableBars;
 
 await game.settings.set("barbrawl", "defaultTypeResources", barConfig);
 
-// :warning: Reset all actors' prototype token bars
-await Promise.all(game.actors.map(a => a.update({ "token.flags.barbrawl.-=resourceBars": null })));
+// Reset the bars on all existing actor Prototype Tokens
+await Promise.all(
+  game.actors.map(a => {
+    let barSettings = mechBars;
+    switch (a.type) {
+      case 'npc':
+        barSettings = npcBars;
+        break;
+      case 'pilot':
+        barSettings = pilotBars;
+        break;
+      case 'deployable':
+        barSettings = deployableBars;
+        break;
+
+      default:
+        break;
+    }
+    a.update({ "prototypeToken.flags.barbrawl.resourceBars": barSettings }, {'diff': false, 'recursive': false})
+  })
+);
 
 // Reset the bars on all existing tokens
 await Promise.all(
@@ -308,7 +327,7 @@ await Promise.all(
         "flags.barbrawl.resourceBars": barSettings,
       };
     });
-    return s.updateEmbeddedDocuments("Token", updates);
+    return s.updateEmbeddedDocuments("Token", updates, {'diff': false, 'recursive': false});
   })
 );
 

--- a/v11/BB_kuenaimaku_v11.js
+++ b/v11/BB_kuenaimaku_v11.js
@@ -102,7 +102,7 @@ barConfig['deployable'] = bars;
 await game.settings.set("barbrawl", "defaultTypeResources", bars);
 
 // :warning: Reset all actors' prototype token bars
-await Promise.all(game.actors.map(a => a.update({ "token.flags.barbrawl.-=resourceBars": null })));
+await Promise.all(game.actors.map(a => a.update({ "token.flags.barbrawl.resourceBars": bars }, {'diff': false, 'recursive': false})));
 
 // Reset the bars on all existing tokens
 await Promise.all(
@@ -113,7 +113,7 @@ await Promise.all(
         "flags.barbrawl.resourceBars": bars,
       };
     });
-    return s.updateEmbeddedDocuments("Token", updates);
+    return s.updateEmbeddedDocuments("Token", updates, {'diff': false, 'recursive': false});
   })
 );
 


### PR DESCRIPTION
# Description

Modify the v11 setup scripts to also update all prototype tokens to use the default bars for their actor type.