### PR TITLE
Zenn' don't nuke everyone else's flags. Also, updates readmes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Bottom bars:
 
 > [!NOTE]
 > This configuration hides HP and Heat bars for NPCs outside of combat and approximates the bars into quarters to reduce player knowledge of enemy stats. To make them visible, add the NPC's to combat.
-> to change this behavior, set the ``hideNoCombat:`` value to false and/or the ``hideNoCombat:`` value to ``""`` for ``npcBars`` ``bar1`` and ``bar2`` before triggering the macro.
+> to change this behavior, set the ``hideNoCombat:`` value to false and/or the ``subdivisions:`` value to ``""`` for ``npcBars`` ``bar1`` and ``bar2`` before triggering the macro.
 
 ![Zenn-BB-config-example](v11/BB_Zenn_v11/Zenn-BB-config-example.png)
 

--- a/README.md
+++ b/README.md
@@ -102,18 +102,21 @@ Bottom bars:
 ![dodgepong-Bar-Brawl-Config-Example](v10/dodgepong-bar-brawl-defaults.png)
 
 ### [Zenn](v11/BB_Zenn_v11)
-## DISCLAIMER
-- **This configuration uses custom assets for all player Mech and NPC stat bars.**
-- The included macro assumes that all the assets will be in ``Data/assets/bars`` If you place the assets somewhere else, the configuration will not render.
-- If you would like to place the assets somewhere else, you'll need to adjust the ``fgImage`` and ``bgImage`` properties in the included macro.
-- It will update actors as well as tokens in scenes, but not tokens or actors stored in compendiums.
-- It currently returns a bunch of errors to the console when running. I'm not sure why, but it updates all the bars you'd expect.
+> [!IMPORTANT]
+> This configuration uses custom asset files for all player Mech and NPC stat bars that you will have to download and place in your default Foundry data directory:
+> ``FoundryVTT/Data/assets/bars`` If you place the assets somewhere else, or do not place them at all, the configuration will not render.
+> If you would like to place the assets somewhere else, you'll need to adjust the ``fgImage`` and ``bgImage`` properties in the included macro.
 
-Notes: 
-- *All PC Bars are always visible to everyone*
-- *NPC Structure and Stress are always visible to everyone*
-- *NPC HP and Heat bars are only visible when the NPC is in combat. These bars are also approximated into quarters, reducing PC ability to guess stats without scans*
--  *PCs have 3 additional indicators, a battery to show if the core power is available, a trio of "hits" in increasingly threatening colors to show the current penalty for overcharging, and a small bar that shows the number of repairs remaining.
+> [!TIP]
+> Visit https://foundryvtt.com/article/user-data-backup/#move for information on Default User Data Locations
+
+> [!NOTE]
+> The included macro updates actors as well as tokens on scenes, but not tokens or actors stored in compendiums.
+> It also returns a bunch of errors to the console while running.  If you know how to fix that, let me know! -Zenn
+
+> [!NOTE]
+> This configuration hides HP and Heat bars for NPCs outside of combat and approximates the bars into quarters to reduce player knowledge of enemy stats. To make them visible, add the NPC's to combat.
+> to change this behavior, set the ``hideNoCombat:`` value to false and/or the ``hideNoCombat:`` value to ``""`` for ``npcBars`` ``bar1`` and ``bar2`` before triggering the macro.
 
 ![Zenn-BB-config-example](v11/BB_Zenn_v11/Zenn-BB-config-example.png)
 

--- a/v11/BB_Zenn_v11/README.md
+++ b/v11/BB_Zenn_v11/README.md
@@ -16,3 +16,5 @@ INSTALL STEPS
 2. Open ``ZennBarBrawlConfigV11.js`` and copy the contents. 
 3. Paste them to a new macro in Foundry, make sure to select ``Script`` from the Type dropdown.
 4. Save and Execute the macro. 
+
+![Zenn-BB-config-example](Zenn-BB-config-example.png)

--- a/v11/BB_Zenn_v11/README.md
+++ b/v11/BB_Zenn_v11/README.md
@@ -1,11 +1,18 @@
-DISCLAIMER
-This configuration uses custom assets for all player Mech and NPC stat bars.  
-The included macro assumes that all the assets will be in ``Data/assets/bars`` If you place the assets somewhere else, the configuration will not render.
-If you would like to place the assets somewhere else, you'll need to adjust the ``fgImage`` and ``bgImage`` properties in the included macro.
+> [!IMPORTANT]
+> This configuration uses custom asset files for all player Mech and NPC stat bars that you will have to download and place in your default Foundry data directory:
+> ``FoundryVTT/Data/assets/bars`` If you place the assets somewhere else, or do not place them at all, the configuration will not render.
+> If you would like to place the assets somewhere else, you'll need to adjust the ``fgImage`` and ``bgImage`` properties in the included macro.
+
+> [!TIP]
+> Visit https://foundryvtt.com/article/user-data-backup/#move for information on Default User Data Locations
+
+> [!NOTE]
+> This configuration hides HP and Heat bars for NPCs outside of combat. To make them visible, add the NPC's to combat.
+> to change this behavior, set the ``hideNoCombat:`` value to false for ``npcBars`` ``bar1`` and ``bar2`` before triggering the macro.
 
 INSTALL STEPS
 
-1. Save the .svg files to your ``Data/assets/bars`` folder
+1. Save the .svg files to ``FoundryVTT/Data/assets/bars`` folder
 2. Open ``ZennBarBrawlConfigV11.js`` and copy the contents. 
 3. Paste them to a new macro in Foundry, make sure to select ``Script`` from the Type dropdown.
 4. Save and Execute the macro. 


### PR DESCRIPTION
Now collects a token's flags and stores them, then reapplies them to the token along with the new BarBrawl flags, thus preserving them.  Couldn't remove ``diff: false`` from ``updateEmbeddedDocuments`` as BarBrawl indent settings that had previously been configured were not being overwritten if the new value was null.

The readmes for Zenn's configuration were made more shiny to address some frequently asked questions.