### PR TITLE
fix(v11 configs): Stop macros from overwriting other flags

### DIFF
--- a/v11/BB_Bolts_v11.js
+++ b/v11/BB_Bolts_v11.js
@@ -61,7 +61,20 @@ barConfig['deployable'] = bars;
 await game.settings.set("barbrawl", "defaultTypeResources", barConfig);
 
 // :warning: Reset all actors' prototype token bars
-await Promise.all(game.actors.map(a => a.update({ "token.flags.barbrawl.resourceBars": bars }, {'diff': false, 'recursive': false})));
+await Promise.all(game.actors.map(a => {
+  // Get existing flags to preserve them
+  const existingFlags = a.flags || {};
+  return a.update({
+    "flags.barbrawl.resourceBars": bars,
+    flags: {
+      ...existingFlags, // Merge existing flags
+      barbrawl: {
+        ...existingFlags.barbrawl,
+        resourceBars: bars
+      }
+    }
+  }, { 'diff': false, 'recursive': false });
+}));
 
 // Reset the bars on all existing tokens
 await Promise.all(
@@ -70,9 +83,16 @@ await Promise.all(
       return {
         _id: t.id,
         "flags.barbrawl.resourceBars": bars,
+        flags: {
+          ...t.flags, // Preserve existing token flags
+          barbrawl: {
+            ...t.flags?.barbrawl,
+            resourceBars: bars
+          }
+        }
       };
     });
-    return s.updateEmbeddedDocuments("Token", updates, {'diff': false, 'recursive': false});
+    return s.updateEmbeddedDocuments("Token", updates, { 'diff': false, 'recursive': false });
   })
 );
 

--- a/v11/BB_dodgepong_v11.js
+++ b/v11/BB_dodgepong_v11.js
@@ -284,7 +284,7 @@ await game.settings.set("barbrawl", "defaultTypeResources", barConfig);
 // Reset the bars on all existing actor Prototype Tokens
 await Promise.all(
   game.actors.map(a => {
-    let barSettings = mechBars;
+    let barSettings;
     switch (a.type) {
       case 'npc':
         barSettings = npcBars;
@@ -295,11 +295,25 @@ await Promise.all(
       case 'deployable':
         barSettings = deployableBars;
         break;
-
       default:
+        barSettings = mechBars;
         break;
     }
-    a.update({ "prototypeToken.flags.barbrawl.resourceBars": barSettings }, {'diff': false, 'recursive': false})
+
+    // Get existing flags to preserve them
+    const existingFlags = a.flags || {};
+
+    // Update the actor while preserving the flags
+    return a.update({
+      "flags.barbrawl.resourceBars": barSettings,
+      flags: {
+        ...existingFlags, // Merge existing flags
+        barbrawl: {
+          ...existingFlags.barbrawl,
+          resourceBars: barSettings
+        }
+      }
+    }, { 'diff': false, 'recursive': false });
   })
 );
 
@@ -307,7 +321,9 @@ await Promise.all(
 await Promise.all(
   game.scenes.map(s => {
     const updates = s.tokens.filter(t => t.actor).map(t => {
-      let barSettings = mechBars;
+      let barSettings;
+
+      // Determine which bar settings to use based on token's actor type
       switch (t.actor.type) {
         case 'npc':
           barSettings = npcBars;
@@ -318,16 +334,24 @@ await Promise.all(
         case 'deployable':
           barSettings = deployableBars;
           break;
-
         default:
+          barSettings = mechBars; // Use mechBars by default
           break;
       }
+
       return {
         _id: t.id,
         "flags.barbrawl.resourceBars": barSettings,
+        flags: {
+          ...t.flags, // Preserve existing token flags
+          barbrawl: {
+            ...t.flags?.barbrawl,
+            resourceBars: barSettings
+          }
+        }
       };
     });
-    return s.updateEmbeddedDocuments("Token", updates, {'diff': false, 'recursive': false});
+    return s.updateEmbeddedDocuments("Token", updates, { 'diff': false, 'recursive': false });
   })
 );
 


### PR DESCRIPTION
# Description

Incorporate the changes from #11 into all other config macros, preventing them from inadvertently overwriting other modules' flags.