### PR TITLE
fix(macros): use Ashgar's snippet to update setup macros

### DIFF
--- a/v11/BB_Bolts_v11.js
+++ b/v11/BB_Bolts_v11.js
@@ -60,7 +60,7 @@ barConfig['deployable'] = bars;
 
 await game.settings.set("barbrawl", "defaultTypeResources", barConfig);
 
-// :warning: Reset all actors' prototype token bars
+// Apply new bar settings to all prototype tokens
 await Promise.all(game.actors.map(a => {
   let target;
   const v = game.version
@@ -69,17 +69,21 @@ await Promise.all(game.actors.map(a => {
   } else if (v >= "12") {
     target = a.prototypeToken
   }
-  // Get existing flags to preserve them
-  const existingFlags = target.flags || {};
-  return target.update({
-    flags: {
-      ...existingFlags, // Merge existing flags
-      barbrawl: {
-        ...existingFlags.barbrawl,
-        resourceBars: bars
-      }
-    }
-  }, { 'diff': false, 'recursive': false });
+
+  return target.unsetFlag('barbrawl', 'resourceBars');
+}));
+
+await Promise.all(game.actors.map(a => {
+
+  let target;
+  const v = game.version
+  if (v < "12" && v >= "11") {
+    target = a
+  } else if (v >= "12") {
+    target = a.prototypeToken
+  }
+  
+  return target.setFlag('barbrawl', 'resourceBars', bars);
 }));
 
 // Reset the bars on all existing tokens

--- a/v11/BB_Valkyrion_v11.js
+++ b/v11/BB_Valkyrion_v11.js
@@ -277,47 +277,48 @@ barConfig['deployable'] = deployableBars;
 
 await game.settings.set("barbrawl", "defaultTypeResources", barConfig);
 
-// Reset the bars on all existing actor Prototype Tokens
-await Promise.all(
-  game.actors.map(a => {
-    let barSettings;
-    switch (a.type) {
-      case 'npc':
-        barSettings = npcBars;
-        break;
-      case 'pilot':
-        barSettings = pilotBars;
-        break;
-      case 'deployable':
-        barSettings = deployableBars;
-        break;
-      default:
-        barSettings = mechBars;
-        break;
-    }
+// Apply new bar settings to all prototype tokens
+await Promise.all(game.actors.map(a => {
+  let target;
+  const v = game.version
+  if (v < "12" && v >= "11") {
+    target = a
+  } else if (v >= "12") {
+    target = a.prototypeToken
+  }
 
-    let target;
-    const v = game.version
-    if (v < "12" && v >= "11") {
-      target = a
-    } else if (v >= "12") {
-      target = a.prototypeToken
-    }
-    // Get existing flags to preserve them
-    const existingFlags = target.flags || {};
+  return target.unsetFlag('barbrawl', 'resourceBars');
+}));
 
-    // Update the actor while preserving the flags
-    return target.update({
-      flags: {
-        ...existingFlags, // Merge existing flags
-        barbrawl: {
-          ...existingFlags.barbrawl,
-          resourceBars: barSettings
-        }
-      }
-    }, { 'diff': false, 'recursive': false });
-  })
-);
+await Promise.all(game.actors.map(a => {
+  let barSettings;
+
+  // Determine which bar settings to use based on actor type
+  switch (a.type) {
+    case 'npc':
+      barSettings = npcBars;
+      break;
+    case 'pilot':
+      barSettings = pilotBars;
+      break;
+    case 'deployable':
+      barSettings = deployableBars;
+      break;
+    default:
+      barSettings = mechBars; // Use mechBars by default
+      break;
+  }
+
+  let target;
+  const v = game.version
+  if (v < "12" && v >= "11") {
+    target = a
+  } else if (v >= "12") {
+    target = a.prototypeToken
+  }
+
+  return target.setFlag('barbrawl', 'resourceBars', barSettings);
+}));
 
 ui.notifications.info("PrototypeToken bar resources updated!");
 
@@ -354,7 +355,7 @@ await Promise.all(
         }
       };
     });
-    
+
     return s.updateEmbeddedDocuments("Token", updates, { 'diff': false, 'recursive': false });
   })
 );

--- a/v11/BB_Zenn_v11/BB_Zenn_V11.js
+++ b/v11/BB_Zenn_v11/BB_Zenn_V11.js
@@ -330,6 +330,18 @@ const deployableBars = {
 // Apply new bar settings to all prototype tokens
 // Update actor flags without overriding other flags
 await Promise.all(game.actors.map(a => {
+  let target;
+  const v = game.version
+  if (v < "12" && v >= "11") {
+    target = a
+  } else if (v >= "12") {
+    target = a.prototypeToken
+  }
+
+  return target.unsetFlag('barbrawl', 'resourceBars');
+}));
+
+await Promise.all(game.actors.map(a => {
   let barSettings;
 
   // Determine which bar settings to use based on actor type
@@ -355,19 +367,8 @@ await Promise.all(game.actors.map(a => {
   } else if (v >= "12") {
     target = a.prototypeToken
   }
-  // Get existing flags to preserve them
-  const existingFlags = target.flags || {};
+  return target.setFlag('barbrawl', 'resourceBars', barSettings);
 
-  // Update the actor while preserving the flags
-  return target.update({
-    flags: {
-      ...existingFlags, // Merge existing flags
-      barbrawl: {
-        ...existingFlags.barbrawl,
-        resourceBars: barSettings
-      }
-    }
-  }, { 'diff': false, 'recursive': false });
 }));
 
 // Reset all tokens' bars in all scenes

--- a/v11/BB_dodgepong_v11.js
+++ b/v11/BB_dodgepong_v11.js
@@ -281,7 +281,19 @@ barConfig['deployable'] = deployableBars;
 
 await game.settings.set("barbrawl", "defaultTypeResources", barConfig);
 
-// Reset the bars on all existing actor Prototype Tokens
+// Apply new bar settings to all prototype tokens
+await Promise.all(game.actors.map(a => {
+  let target;
+  const v = game.version
+  if (v < "12" && v >= "11") {
+    target = a
+  } else if (v >= "12") {
+    target = a.prototypeToken
+  }
+
+  return target.unsetFlag('barbrawl', 'resourceBars');
+}));
+
 await Promise.all(
   game.actors.map(a => {
     let barSettings;
@@ -311,15 +323,8 @@ await Promise.all(
     const existingFlags = target.flags || {};
 
     // Update the actor while preserving the flags
-    return target.update({
-      flags: {
-        ...existingFlags, // Merge existing flags
-        barbrawl: {
-          ...existingFlags.barbrawl,
-          resourceBars: barSettings
-        }
-      }
-    }, { 'diff': false, 'recursive': false });
+    return target.setFlag('barbrawl', 'resourceBars', barSettings);
+
   })
 );
 

--- a/v11/BB_kuenaimaku_v11.js
+++ b/v11/BB_kuenaimaku_v11.js
@@ -102,6 +102,7 @@ barConfig['deployable'] = bars;
 await game.settings.set("barbrawl", "defaultTypeResources", bars);
 
 // :warning: Reset all actors' prototype token bars
+// Apply new bar settings to all prototype tokens
 await Promise.all(game.actors.map(a => {
   let target;
   const v = game.version
@@ -110,17 +111,19 @@ await Promise.all(game.actors.map(a => {
   } else if (v >= "12") {
     target = a.prototypeToken
   }
-  // Get existing flags to preserve them
-  const existingFlags = target.flags || {};
-  return target.update({
-    flags: {
-      ...existingFlags, // Merge existing flags
-      barbrawl: {
-        ...existingFlags.barbrawl,
-        resourceBars: bars
-      }
-    }
-  }, { 'diff': false, 'recursive': false });
+
+  return target.unsetFlag('barbrawl', 'resourceBars');
+}));
+
+await Promise.all(game.actors.map(a => {
+  let target;
+  const v = game.version
+  if (v < "12" && v >= "11") {
+    target = a
+  } else if (v >= "12") {
+    target = a.prototypeToken
+  }
+  return target.setFlag('barbrawl', 'resourceBars', bars);
 }));
 
 // Reset the bars on all existing tokens

--- a/v12/BB_sarah_v12.js
+++ b/v12/BB_sarah_v12.js
@@ -691,47 +691,48 @@ barConfig['deployable'] = deployableBars;
 
 await game.settings.set("barbrawl", "defaultTypeResources", barConfig);
 
-// Reset the bars on all existing actor Prototype Tokens
-await Promise.all(
-  game.actors.map(a => {
-    let barSettings;
-    switch (a.type) {
-      case 'npc':
-        barSettings = npcBars;
-        break;
-      case 'pilot':
-        barSettings = pilotBars;
-        break;
-      case 'deployable':
-        barSettings = deployableBars;
-        break;
-      default:
-        barSettings = mechBars;
-        break;
-    }
+// Apply new bar settings to all prototype tokens
+await Promise.all(game.actors.map(a => {
+  let target;
+  const v = game.version
+  if (v < "12" && v >= "11") {
+    target = a
+  } else if (v >= "12") {
+    target = a.prototypeToken
+  }
 
-    let target;
-    const v = game.version
-    if (v < "12" && v >= "11") {
-      target = a
-    } else if (v >= "12") {
-      target = a.prototypeToken
-    }
-    // Get existing flags to preserve them
-    const existingFlags = target.flags || {};
+  return target.unsetFlag('barbrawl', 'resourceBars');
+}));
 
-    // Update the actor while preserving the flags
-    return target.update({
-      flags: {
-        ...existingFlags, // Merge existing flags
-        barbrawl: {
-          ...existingFlags.barbrawl,
-          resourceBars: barSettings
-        }
-      }
-    }, { 'diff': false, 'recursive': false });
-  })
-);
+await Promise.all(game.actors.map(a => {
+  let barSettings;
+
+  // Determine which bar settings to use based on actor type
+  switch (a.type) {
+    case 'npc':
+      barSettings = npcBars;
+      break;
+    case 'pilot':
+      barSettings = pilotBars;
+      break;
+    case 'deployable':
+      barSettings = deployableBars;
+      break;
+    default:
+      barSettings = mechBars; // Use mechBars by default
+      break;
+  }
+
+  let target;
+  const v = game.version
+  if (v < "12" && v >= "11") {
+    target = a
+  } else if (v >= "12") {
+    target = a.prototypeToken
+  }
+  
+  return target.setFlag('barbrawl', 'resourceBars', barSettings);
+}));
 
 ui.notifications.info("PrototypeToken bar resources updated!");
 


### PR DESCRIPTION
Including code snippets from @Ashgar225 to update the macros to work on v13 as well as v11 and v12.

Noted issue on v11 on master: Prototype tokens are not updated by the macros. This PR does not affect that behavior, but neither does it cause it.

UPDATE: There may be some odd behavior with Deployables on the Zenn config, as per Ashgar on Pilot NET.